### PR TITLE
add select-entry based on existing code from select-popup

### DIFF
--- a/example/whiteboard/demo-input.tsx
+++ b/example/whiteboard/demo-input.tsx
@@ -14,6 +14,8 @@ import NumberPopup from "../../src/number-popup";
 import LabelFieldVertical from "../../src/label-field-vertical";
 import { Switch } from "antd-mobile";
 import FormSectionTitle from "../../src/form-section-title";
+import { materialSelectItems } from "../data/material-items";
+import SelectEntry from "../../src/select-entry";
 
 interface IProps {}
 
@@ -64,6 +66,8 @@ export default class WhiteboardDemoInput extends React.Component<IProps, IState>
           <ThinDivider />
           {this.renderSelectDemo()}
           <ThinDivider />
+          {this.renderSelectEntry()}
+          <ThinDivider />
           {this.renderSelectInputDemo()}
           <ThinDivider />
           {this.renderInputVerticalDemo()}
@@ -98,6 +102,24 @@ export default class WhiteboardDemoInput extends React.Component<IProps, IState>
           disabled={this.state.disabled}
           atRight={true}
           options={options}
+          onChange={(text: string) => {
+            this.immerState((state) => {
+              state.selected = text;
+            });
+          }}
+        />
+      </LabelField>
+    );
+  }
+
+  renderSelectEntry() {
+    return (
+      <LabelField label={"Navigator select"}>
+        <SelectEntry
+          value={this.state.selected}
+          disabled={this.state.disabled}
+          atRight={true}
+          options={materialSelectItems}
           onChange={(text: string) => {
             this.immerState((state) => {
               state.selected = text;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/mescal-ui",
-  "version": "0.1.0",
+  "version": "0.1.1-a1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/mescal-ui",
-  "version": "0.1.1-a1",
+  "version": "0.1.1-a3",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,12 @@ export { default as SelectSopup } from "./select-popup";
 export { default as TextareaPopup } from "./textarea-popup";
 export { default as TreeSelecPopup } from "./tree-select-popup";
 
+// Navigator
+
+export { default as NavigatorPage } from "./navigator-page";
+export { default as NavigatorSelect } from "./navigator-select";
+export { default as SelectEntry } from "./select-entry";
+
 // header
 
 export { default as NavHeader } from "./nav-header";
@@ -49,8 +55,6 @@ export { default as FormSectionTitle } from "./form-section-title";
 export { default as IconLabel } from "./icon-label";
 export { default as InputInline } from "./input-inline";
 export { default as LoadingPlaceholder } from "./loading-placeholder";
-export { default as NavigatorPage } from "./navigator-page";
-export { default as NavigatorSelect } from "./navigator-select";
 export { default as ProgressPercent } from "./progress-percent";
 export { default as RoughTable } from "./rough-table";
 export { default as SamplingCounter } from "./sampling-counter";

--- a/src/navigator-page.tsx
+++ b/src/navigator-page.tsx
@@ -31,7 +31,7 @@ export default class NavigatorPage extends React.Component<IProps, any> {
 
   render() {
     return ReactDOM.createPortal(
-      <div>
+      <div onClick={this.onContainerClick}>
         <TransitionGroup className={styleAnimations}>
           {this.props.visible ? (
             <CSSTransition classNames="backdrop" timeout={{ enter: transitionDuration, exit: transitionDuration }}>
@@ -47,6 +47,10 @@ export default class NavigatorPage extends React.Component<IProps, any> {
       </div>,
       this.el
     );
+  }
+
+  onContainerClick(event) {
+    event.stopPropagation();
   }
 }
 

--- a/src/navigator-select.tsx
+++ b/src/navigator-select.tsx
@@ -9,6 +9,10 @@ import IconInput from "./icon-input";
 import { ISelectPopupItem } from "./select-popup";
 import EmptyPlaceholder from "./empty-placeholder";
 
+let found = (x: string, y: string) => {
+  return x.toLocaleLowerCase().includes(y.trim().toLowerCase());
+};
+
 interface IProps {
   visible: boolean;
   title?: string;
@@ -46,7 +50,7 @@ let NavigatorSelect: SFC<IProps> = (props) => {
   let filteredOptions = props.options;
   if (query.trim().length > 0) {
     filteredOptions = filteredOptions.filter((item) => {
-      return (item.searchText || item.display).includes(query);
+      return found(item.searchText || item.display, query);
     });
   }
 

--- a/src/select-entry.tsx
+++ b/src/select-entry.tsx
@@ -1,0 +1,181 @@
+import React, { ReactNode } from "react";
+import _ from "lodash";
+import { css, cx } from "emotion";
+import { immerHelpers, ImmerStateFunc, MergeStateFunc } from "@jimengio/shared-utils";
+
+import { lingual, formatString } from "./lingual";
+import Space from "./space";
+import FaIcon, { IconName } from "@jimengio/fa-icons";
+import { showInfoAlertMessage } from "./message/message-center";
+import NavigatorSelect from "./navigator-select";
+
+export interface ISelectPopupItem {
+  key?: string;
+  display: any;
+  value: any;
+  searchText?: string;
+}
+
+interface IProps {
+  value: string;
+  guideText?: string;
+  placeholder?: string;
+  atRight?: boolean;
+  options: ISelectPopupItem[];
+  onChange: (text: string) => void;
+  disabled?: boolean;
+  isLoading?: boolean;
+  disabledMessage?: string;
+  maxPreviewWidth?: number;
+  navigatorTitle?: string;
+  navigatorHint?: string;
+}
+
+interface IState {
+  isEditing: boolean;
+  query: string;
+}
+
+export default class SelectPopup extends React.Component<IProps, IState> {
+  inputEl: HTMLInputElement;
+
+  constructor(props: IProps) {
+    super(props);
+
+    this.state = {
+      isEditing: false, // debug
+      query: "",
+    };
+  }
+
+  immerState = immerHelpers.immerState as ImmerStateFunc<IState>;
+  mergeState = immerHelpers.mergeState as MergeStateFunc<IState>;
+
+  render() {
+    return (
+      <div
+        className={cx(styleContainer, this.state.isEditing ? styleOutline : null, this.props.disabled ? styleDisabled : null)}
+        onClick={() => {
+          if (this.props.disabled) {
+            showInfoAlertMessage(this.props.disabledMessage || lingual.inputIsDisabled);
+            return;
+          }
+
+          this.immerState((state) => {
+            state.isEditing = true;
+          });
+        }}
+      >
+        {this.renderValue()}
+        {this.renderEditor()}
+      </div>
+    );
+  }
+
+  renderValue() {
+    let { options, value, placeholder, isLoading } = this.props;
+
+    if (isLoading) {
+      return this.renderValuePreview(styleEmpty, lingual.loading);
+    } else if (value != null) {
+      return this.renderValuePreview(styleValue, this.displayValue(value));
+    } else if (placeholder != null) {
+      return this.renderValuePreview(styleEmpty, placeholder);
+    } else if (_.isEmpty(options)) {
+      return this.renderValuePreview(styleEmpty, lingual.noCandidates);
+    } else {
+      return this.renderValuePreview(styleEmpty, formatString(lingual.xCandidates, { x: options.length }));
+    }
+  }
+
+  renderValuePreview(className: string, content: ReactNode) {
+    let { atRight } = this.props;
+
+    return (
+      <div className={className} style={{ textAlign: atRight ? "right" : "left" }}>
+        <div className={stylePreview} style={{ maxWidth: this.props.maxPreviewWidth }}>
+          {content}
+        </div>
+        <Space width={8} />
+        <FaIcon name={IconName.AngleDown} />
+      </div>
+    );
+  }
+
+  displayValue(value: string) {
+    let { options } = this.props;
+
+    let target = options.find((x) => x.value === value);
+
+    return target != null ? target.display : this.renderInvalid(value);
+  }
+
+  renderEditor() {
+    return (
+      <NavigatorSelect
+        visible={this.state.isEditing}
+        title={this.props.navigatorTitle}
+        hint={this.props.navigatorHint}
+        onCancel={() => {
+          this.mergeState({
+            isEditing: false,
+          });
+        }}
+        options={this.props.options}
+        onSelect={(x) => {
+          this.props.onChange(x);
+          this.mergeState({ isEditing: false });
+        }}
+      />
+    );
+  }
+
+  renderInvalid(x) {
+    return <span className={styleInvalid}>{x}</span>;
+  }
+}
+
+const styleValue = css`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const styleInvalid = css`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: red;
+`;
+
+const styleEmpty = css`
+  white-space: nowrap;
+  color: #ccc;
+  font-style: italic;
+`;
+
+const styleContainer = css`
+  display: inline-block;
+  min-width: 64px;
+  max-width: 320px;
+  border: 1px solid #ddd;
+  padding: 0 8px;
+  border-radius: 2px;
+  line-height: 32px;
+  overflow: auto;
+  background-color: white;
+`;
+
+const styleOutline = css`
+  outline: 2px solid #aaf;
+`;
+
+const styleDisabled = css`
+  background-color: #f0f0f0;
+`;
+
+const stylePreview = css`
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+`;


### PR DESCRIPTION
Add an trigger area with existing code from select-popup as a bridge to render navigator:

![image](https://user-images.githubusercontent.com/25790987/54431079-65b05c00-4760-11e9-96c3-95aa9aa0bcac.png)
