### PR TITLE
reset number value when invalid number input; alpha release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ webpack/*
 tsconfig*
 dist/
 template.ejs
+*.log

--- a/example/whiteboard/demo-inputs-inine.tsx
+++ b/example/whiteboard/demo-inputs-inine.tsx
@@ -85,18 +85,21 @@ export default class WhiteboardDemoInputsInline extends React.Component<IProps, 
 
   renderNumberInlineDemo() {
     return (
-      <LabelField label={"Basic number"} underline>
-        <NumberInline
-          value={this.state.size}
-          atRight={true}
-          disabled={this.state.disabled}
-          onChange={(x: number) => {
-            this.immerState((state) => {
-              state.size = x;
-            });
-          }}
-        />
-      </LabelField>
+      <>
+        <LabelField label={"Basic number"} underline>
+          <NumberInline
+            value={this.state.size}
+            atRight={true}
+            disabled={this.state.disabled}
+            onChange={(x: number) => {
+              this.immerState((state) => {
+                state.size = x;
+              });
+            }}
+          />
+        </LabelField>
+        <LabelField label={"value is:"}>{this.state.size}</LabelField>
+      </>
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/mescal-ui",
-  "version": "0.1.9",
+  "version": "0.1.10-a2",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/number-inline.tsx
+++ b/src/number-inline.tsx
@@ -99,8 +99,12 @@ export default class NumberInline extends React.Component<IProps, IState> {
           // console.log("change", JSON.stringify(text), maybeNumber);
           if (maybeNumber != null) {
             this.props.onChange(maybeNumber);
+          } else if (text.trim() === "") {
+            // submit empty
+            // <input/> also returns empty string when value is invalid
+            this.props.onChange(null);
           } else {
-            this.props.onChange(text as any);
+            // do no submit invalid values
           }
         }}
         className={styleInput}
@@ -120,6 +124,12 @@ export default class NumberInline extends React.Component<IProps, IState> {
         state.isEditing = false;
       });
       this.props.onChange(maybeNumber);
+    } else {
+      // reset draft state if value is not valid
+      this.immerState((state) => {
+        state.isEditing = false;
+        state.draft = this.props.value as any;
+      });
     }
   };
 


### PR DESCRIPTION
Changed behavior of number inline a bit http://fe.jimu.io/mescal-ui/#/inputs-inline . State will be reset when blur after user input an invalid string for the value.
